### PR TITLE
removing dependency on typography since no mixins are being used

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,14 +26,13 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "~1.7.1",
+    "polymer": "^1.7.1",
     "d2l-ajax": "^3.2.5",
-    "d2l-colors": "~2.2.3",
+    "d2l-colors": "^2.2.3",
     "d2l-course-image": "git://github.com/Brightspace/course-image.git#~0.0.1",
     "d2l-icons": "^3.0.0",
     "d2l-loading-spinner": "^5.0.2",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#~0.0.1",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^1.0.0",
-    "d2l-typography": "~5.2.3"
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^1.0.0"
   }
 }

--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -4,13 +4,12 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
-<link rel="import" href="../d2l-typography/d2l-typography.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-image-tile-grid.html">
 
 <dom-module id="d2l-basic-image-selector">
 	<template>
-		<style include="d2l-typography">
+		<style>
 			#image-search{
 				width: 50%;
 			}
@@ -84,7 +83,7 @@
 			method="POST">
 		</d2l-ajax>
 
-		<div class="d2l-typography top-section">
+		<div class="top-section">
 			<d2l-search-widget
 				id="image-search"
 				class="small"
@@ -115,7 +114,7 @@
 		</template>
 
 		<template is="dom-if" if="{{!_showGrid}}">
-			<div class="d2l-typography no-results-area">
+			<div class="no-results-area">
 				<div class="no-results-text">
 					<span>{{_noResultsTextStart}}</span><span class="no-results-search-text">{{_noResultsTextMid}}</span><span>{{_noResultsTextEnd}}</span>
 				</div>


### PR DESCRIPTION
@ryantmer, @cgalvind2l, @jstefaniuk-d2l: Typography should only ever be needed in an individual component like this if you need to call into one of its mixins.

You can depend on the outer page (BSI in the case of the LMS) to include typography once for use by everything on the page. Otherwise, it gets applied over and over again every time the `d2l-typography` class is used and it's really just a redundant and costly operation.