### PR TITLE
Remove d2l-siren-parser

### DIFF
--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -127,6 +127,7 @@
 			size="100">
 		</d2l-loading-spinner>
 	</template>
+	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 	<script>
 		'use strict';
 
@@ -176,7 +177,6 @@
 					'_searchResultsChanged'
 				);
 			},
-			_sirenParser: document.createElement('d2l-siren-parser'),
 			_searchImages: [],
 			_defaultImages: [],
 			_searchResultsChanged: function(response) {
@@ -227,13 +227,16 @@
 				this._showGrid = true;
 				this._nextSearchResultPage = null;
 			},
+			_parseEntity: function(entity) {
+				return window.D2L.Hypermedia.Siren.Parse(entity);
+			},
 			_onImagesRequestResponse: function(response, loadMore, isDefault) {
 				this._loadingSpinnerClass = 'd2l-basic-image-selector-hidden';
 				if (response.detail.status !== 200) {
 					return;
 				}
 
-				var parsedResponse = this._sirenParser.parse(response.detail.xhr.response);
+				var parsedResponse = this._parseEntity(response.detail.xhr.response);
 				var newImages;
 
 				if (loadMore) {

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.html
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.html
@@ -6,7 +6,6 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../../d2l-siren-parser/d2l-siren-parser.html">
 		<link rel="import" href="../../d2l-basic-image-selector.html">
 	</head>
 	<body>

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.js
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.js
@@ -126,7 +126,7 @@ describe('<d2l-course-tile>', function() {
 
 	describe('_initialize', function() {
 		beforeEach(function() {
-			widget._sirenParser.parse = sinon.stub().returns({});
+			widget._parseEntity = sinon.stub().returns({});
 			widget.imageCatalogLocation = 'http://test.com';
 			widget._getChangeCourseImageLink = sinon.stub();
 			widget.$.imagesRequest.generateRequest = sinon.stub();
@@ -171,7 +171,7 @@ describe('<d2l-course-tile>', function() {
 				}
 			};
 
-			widget._sirenParser.parse = sinon.stub().returns({
+			widget._parseEntity = sinon.stub().returns({
 				entities: [4, 5, 6]
 			});
 			widget._setNextPage = sinon.stub();


### PR DESCRIPTION
Missed this one when I deprecated it as it wasn't referenced in bower.json. Fixed now!