### PR TITLE
Us89544   course image upload from lms

### DIFF
--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -101,7 +101,7 @@
 				<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
 				<span class="upload-text">{{localize('upload')}}</span>
 			</div>
-			
+
 		</div>
 
 		<template is="dom-if" if="{{_showGrid}}">
@@ -347,16 +347,14 @@
 			_onDefaultImagesRequestResponse: function(response) {
 				this._onImagesRequestResponse(response, false, true);
 			},
-			_uploadTelemetry: function(e) {
-				if ((e.type === 'keydown' && e.keyCode === 13) || (e.type === 'tap')) {
-					this._telemetryEvent = JSON.stringify({
-						ts: Math.round(Date.now() / 1000),
-						name: 'CourseImageUpload',
-						userId: this.userId,
-						tenantId: this.tenantId
-					});
-					this.$.telemetryRequest.generateRequest();
-				}
+			_uploadTelemetry: function() {
+				this._telemetryEvent = JSON.stringify({
+					ts: Math.round(Date.now() / 1000),
+					name: 'CourseImageUpload',
+					userId: this.userId,
+					tenantId: this.tenantId
+				});
+				this.$.telemetryRequest.generateRequest();
 			},
 			_doTelemetryNextPageRequest: function(parsedResponse) {
 				var searchRegex = /search=([^&]*)/,
@@ -404,7 +402,7 @@
 			},
 			_handleUpload: function(e) {
 				if ((e.type === 'keydown' && e.keyCode === 13) || (e.type === 'tap')) {
-					this._uploadTelemetry(e);
+					this._uploadTelemetry();
 					if (this.courseImageUploadCb) {
 						this.courseImageUploadCb();
 					} else {

--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -31,6 +31,10 @@
 				margin-bottom: 45px;
 			}
 
+			div.upload {
+				cursor: pointer;
+			}
+
 			.upload-text {
 				margin-left: 5px;
 			}
@@ -93,7 +97,14 @@
 				cache-responses>
 			</d2l-search-widget>
 
-			<template is="dom-if" if="{{_organizationChangeImageHref}}" restamp="true">
+			<template is="dom-if" if="{{!_showUploadAsLink()}}" restamp="true">
+				<div role="button" tabindex="0" class="upload" on-tap="_handleUpload" on-keydown="_handleUpload">
+					<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
+					<span class="upload-text">{{localize('upload')}}</span>
+				</div>
+			</template>
+
+			<template is="dom-if" if="{{_showUploadAsLink()}}" restamp="true">
 				<a class="upload" href$=[[_organizationChangeImageHref]] on-tap="_uploadTelemetry" on-keydown="_uploadTelemetry">
 					<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
 					<span class="upload-text">{{localize('upload')}}</span>
@@ -136,6 +147,7 @@
 				this._images = this._defaultImages;
 			},
 			properties: {
+				courseImageUploadCb: Function,
 				imageCatalogLocation: String,
 				organization: Object,
 				userId: String,
@@ -220,6 +232,9 @@
 				}
 
 				this.fire('clear-image-scroll-threshold');
+			},
+			_showUploadAsLink: function() {
+				return !this.courseImageUploadCb;
 			},
 			_displayDefaultResults: function() {
 				this._searchImages = [];
@@ -397,6 +412,12 @@
 					tenantId: this.tenantId
 				});
 				this.$.telemetryRequest.generateRequest();
+			},
+			_handleUpload: function(e) {
+				if ((e.type === 'keydown' && e.keyCode === 13) || (e.type === 'tap')) {
+					this._uploadTelemetry(e);
+					this.courseImageUploadCb();
+				}
 			}
 		});
 	</script>

--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -97,19 +97,11 @@
 				cache-responses>
 			</d2l-search-widget>
 
-			<template is="dom-if" if="{{!_showUploadAsLink()}}" restamp="true">
-				<div role="button" tabindex="0" class="upload" on-tap="_handleUpload" on-keydown="_handleUpload">
-					<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
-					<span class="upload-text">{{localize('upload')}}</span>
-				</div>
-			</template>
-
-			<template is="dom-if" if="{{_showUploadAsLink()}}" restamp="true">
-				<a class="upload" href$=[[_organizationChangeImageHref]] on-tap="_uploadTelemetry" on-keydown="_uploadTelemetry">
-					<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
-					<span class="upload-text">{{localize('upload')}}</span>
-				</a>
-			</template>
+			<div role="button" tabindex="0" class="upload" on-tap="_handleUpload" on-keydown="_handleUpload">
+				<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
+				<span class="upload-text">{{localize('upload')}}</span>
+			</div>
+			
 		</div>
 
 		<template is="dom-if" if="{{_showGrid}}">
@@ -232,9 +224,6 @@
 				}
 
 				this.fire('clear-image-scroll-threshold');
-			},
-			_showUploadAsLink: function() {
-				return !this.courseImageUploadCb;
 			},
 			_displayDefaultResults: function() {
 				this._searchImages = [];
@@ -416,7 +405,11 @@
 			_handleUpload: function(e) {
 				if ((e.type === 'keydown' && e.keyCode === 13) || (e.type === 'tap')) {
 					this._uploadTelemetry(e);
-					this.courseImageUploadCb();
+					if (this.courseImageUploadCb) {
+						this.courseImageUploadCb();
+					} else {
+						window.location.href = this._organizationChangeImageHref;
+					}
 				}
 			}
 		});

--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -97,10 +97,12 @@
 				cache-responses>
 			</d2l-search-widget>
 
-			<div role="button" tabindex="0" class="upload" on-tap="_handleUpload" on-keydown="_handleUpload">
-				<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
-				<span class="upload-text">{{localize('upload')}}</span>
-			</div>
+			<template is="dom-if" if="{{_organizationChangeImageHref}}" restamp="true">
+				<div role="button" tabindex="0" class="upload" on-tap="_handleUpload" on-keydown="_handleUpload">
+					<d2l-icon class="upload-icon" icon="d2l-tier2:upload" aria-hidden="true"></d2l-icon>
+					<span class="upload-text">{{localize('upload')}}</span>
+				</div>
+			</template>
 
 		</div>
 


### PR DESCRIPTION
Allow a course image upload callback to be specified.  Use that instead of href for upload.  

I converted the upload link to button regardless if the callback is supplied or not.  At first I tried to retain use of an anchor if the callback is not provided but it made things unnecessarily complicated.  I think just using a button is fine considering we intend to only ever provide a callback in the LMS once the related flag is turned on all the time.

I used a div with role button because the button introduced a bunch of default styles that I didn't want to contend with.