### PR TITLE
US90806 - d2l-search-widget update + switch to d2l-fetch

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,3 +7,4 @@ globals:
   Polymer: false
   WCT: false
   D2L: false
+  Promise: false

--- a/bower.json
+++ b/bower.json
@@ -27,13 +27,13 @@
   ],
   "dependencies": {
     "polymer": "^1.8.0",
-    "d2l-ajax": "^3.4.1",
     "d2l-colors": "^2.3.0",
-    "d2l-course-image": "git://github.com/Brightspace/course-image.git#^1.0.1",
+    "d2l-course-image": "Brightspace/course-image#^1.0.1",
+    "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1",
     "d2l-icons": "^3.2.0",
     "d2l-loading-spinner": "^5.0.4",
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.1",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.0.0"
+    "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^1.0.1",
+    "d2l-search-widget": "Brightspace/d2l-search-widget-ui#^2.0.1"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-fetch/d2l-fetch.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
@@ -58,43 +58,13 @@
 			}
 		</style>
 
-		<d2l-ajax
-			id="imagesRequest"
-			url="[[_searchString]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onDefaultImagesRequestResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="moreDefaultImagesRequest"
-			url="[[_nextDefaultResultPage]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_moreDefaultImagesRequestResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="moreSearchImagesRequest"
-			url="[[_nextSearchResultPage]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_moreSearchImagesRequestResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="telemetryRequest"
-			url="[[telemetryEndpoint]]"
-			headers='{ "Content-Type": "application/json" }'
-			body="[[_telemetryEvent]]"
-			method="POST">
-		</d2l-ajax>
-
 		<div class="top-section">
 			<d2l-search-widget
 				id="image-search"
 				class="small"
 				search-action="[[_searchAction]]"
 				placeholder-text="[[localize('search')]]"
-				search-field-name="search"
-				cache-responses>
+				search-field-name="search">
 			</d2l-search-widget>
 
 			<template is="dom-if" if="{{_organizationChangeImageHref}}" restamp="true">
@@ -160,8 +130,7 @@
 				_loadingSpinnerClass: {
 					type: String,
 					value: 'd2l-basic-image-selector-hidden'
-				},
-				_telemetryEvent: String
+				}
 			},
 			behaviors: [ window.D2L.ImageSelector.LocalizeBehavior ],
 			listeners: {
@@ -232,26 +201,19 @@
 				this._showGrid = true;
 				this._nextSearchResultPage = null;
 			},
-			_parseEntity: function(entity) {
-				return window.D2L.Hypermedia.Siren.Parse(entity);
-			},
-			_onImagesRequestResponse: function(response, loadMore, isDefault) {
+			_onImagesRequestResponse: function(responseEntity, loadMore, isDefault) {
 				this._loadingSpinnerClass = 'd2l-basic-image-selector-hidden';
-				if (response.detail.status !== 200) {
-					return;
-				}
 
-				var parsedResponse = this._parseEntity(response.detail.xhr.response);
 				var newImages;
 
 				if (loadMore) {
 					newImages = (isDefault ? this._defaultImages : this._searchImages) || [];
-					newImages = newImages.concat(parsedResponse.entities);
+					newImages = newImages.concat(responseEntity.entities);
 
-					this._doTelemetryNextPageRequest(parsedResponse);
+					this._doTelemetryNextPageRequest(responseEntity);
 
 				} else {
-					newImages = parsedResponse.entities;
+					newImages = responseEntity.entities;
 				}
 
 				if (isDefault) {
@@ -259,7 +221,7 @@
 				} else {
 					this._searchImages = newImages;
 				}
-				this._setNextPage(parsedResponse, isDefault);
+				this._setNextPage(responseEntity, isDefault);
 				this._updateImages();
 			},
 			_initialize: function() {
@@ -277,7 +239,8 @@
 				}
 
 				if (this._searchString !== null) {
-					this.$.imagesRequest.generateRequest();
+					return this._fetchSirenEntity(this._searchString)
+						.then(this._onDefaultImagesRequestResponse.bind(this));
 				}
 			},
 			_clear: function() {
@@ -329,41 +292,44 @@
 				}
 
 				if (this._nextSearchResultPage) {
-					this.$.moreSearchImagesRequest.generateRequest();
 					this._loadingSpinnerClass = '';
 					this.$.lazyLoadSpinner.scrollIntoView();
+					return this._fetchSirenEntity(this._nextSearchResultPage)
+						.then(this._moreSearchImagesRequestResponse.bind(this));
 				} else if (this._nextDefaultResultPage && (this._searchImages || []).length === 0) {
 					this._loadingSpinnerClass = '';
 					this.$.lazyLoadSpinner.scrollIntoView();
-					this.$.moreDefaultImagesRequest.generateRequest();
+					return this._fetchSirenEntity(this._nextDefaultResultPage)
+						.then(this._moreDefaultImagesRequestResponse.bind(this));
 				} else {
 					this._loadingSpinnerClass = 'd2l-basic-image-selector-hidden';
 				}
 			},
-			_moreDefaultImagesRequestResponse: function(response) {
-				this._onImagesRequestResponse(response, true, true);
+			_moreDefaultImagesRequestResponse: function(responseEntity) {
+				this._onImagesRequestResponse(responseEntity, true, true);
 			},
-			_moreSearchImagesRequestResponse: function(response) {
-				this._onImagesRequestResponse(response, true, false);
+			_moreSearchImagesRequestResponse: function(responseEntity) {
+				this._onImagesRequestResponse(responseEntity, true, false);
 			},
-			_onDefaultImagesRequestResponse: function(response) {
-				this._onImagesRequestResponse(response, false, true);
+			_onDefaultImagesRequestResponse: function(responseEntity) {
+				this._onImagesRequestResponse(responseEntity, false, true);
 			},
 			_uploadTelemetry: function() {
-				this._telemetryEvent = JSON.stringify({
+				var event = {
 					ts: Math.round(Date.now() / 1000),
 					name: 'CourseImageUpload',
 					userId: this.userId,
 					tenantId: this.tenantId
-				});
-				this.$.telemetryRequest.generateRequest();
+				};
+
+				this._sendTelemetryEvent(event);
 			},
-			_doTelemetryNextPageRequest: function(parsedResponse) {
+			_doTelemetryNextPageRequest: function(entity) {
 				var searchRegex = /search=([^&]*)/,
 					match = searchRegex.exec(this._searchString);
 				var searchWidget = this.$$('d2l-search-widget');
-				var pagingInfo = this._getPagingInfo(parsedResponse);
-				this._telemetryEvent = JSON.stringify({
+				var pagingInfo = this._getPagingInfo(entity);
+				var event = {
 					ts: Math.round(Date.now() / 1000),
 					name: 'NextImagePageNavigation',
 					resultsPageNumber: pagingInfo.page,
@@ -371,16 +337,17 @@
 					search: searchWidget._searchString === '' ? match[1] : searchWidget._searchString,
 					userId: this.userId,
 					tenantId: this.tenantId
-				});
-				this.$.telemetryRequest.generateRequest();
+				};
+
+				this._sendTelemetryEvent(event);
 			},
-			_getPagingInfo: function(parsedResponse) {
+			_getPagingInfo: function(entity) {
 				var pagingInfo = {
 					page: 'error retrieving page info',
 					total: 'error retrieving total info'
 				};
-				if (parsedResponse.properties && parsedResponse.properties.pagingInfo) {
-					pagingInfo = parsedResponse.properties.pagingInfo;
+				if (entity.properties && entity.properties.pagingInfo) {
+					pagingInfo = entity.properties.pagingInfo;
 				}
 				return pagingInfo;
 			},
@@ -392,15 +359,16 @@
 							&& searchWidget.searchResults.properties.pagingInfo.total
 							? searchWidget.searchResults.properties.pagingInfo.total
 							: 0;
-				this._telemetryEvent = JSON.stringify({
+				var event = {
 					ts: Math.round(Date.now() / 1000),
 					name: 'SearchImageCatalog',
 					totalResults: total,
 					search: searchWidget._searchString,
 					userId: this.userId,
 					tenantId: this.tenantId
-				});
-				this.$.telemetryRequest.generateRequest();
+				};
+
+				this._sendTelemetryEvent(event);
 			},
 			_handleUpload: function(e) {
 				if ((e.type === 'keydown' && e.keyCode === 13) || (e.type === 'tap')) {
@@ -411,6 +379,31 @@
 						window.location.href = this._organizationChangeImageHref;
 					}
 				}
+			},
+			_fetchSirenEntity: function(url) {
+				return window.d2lfetch
+					.fetch(new Request(url, {
+						headers: {
+							Accept: 'application/vnd.siren+json'
+						}
+					}))
+					.then(function(response) {
+						if (response.ok) {
+							return response.json();
+						}
+						Promise.reject(response.status + ' ' + response.statusText);
+					})
+					.then(window.D2L.Hypermedia.Siren.Parse);
+			},
+			_sendTelemetryEvent: function(event) {
+				return window.d2lfetch
+					.fetch(new Request(this.telemetryEndpoint, {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json'
+						},
+						body: JSON.stringify(event)
+					}));
 			}
 		});
 	</script>

--- a/d2l-image-selector-tile.html
+++ b/d2l-image-selector-tile.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-fetch/d2l-fetch.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-course-image/d2l-course-image.html">
 <link rel="import" href="d2l-course-tile-grid-styles.html">
@@ -44,23 +44,6 @@
 			<div class="d2l-image-tile-content">
 				<d2l-course-image image="[[image]]" sizes="[[_imageSizes]]" type="narrow"></d2l-course-image>
 			</div>
-
-			<d2l-ajax
-				id="setImageRequest"
-				url="[[_setImageUrl]]"
-				method="POST"
-				headers='{ "Accept": "application/vnd.siren+json" }'
-				on-iron-ajax-response="_onSetImageResponse"
-				on-iron-ajax-error="_onSetImageError">
-			</d2l-ajax>
-			<d2l-ajax
-				id="telemetryRequest"
-				url="[[telemetryEndpoint]]"
-				headers='{ "Content-Type": "application/json" }'
-				body="[[_telemetryEvent]]"
-				method="POST">
-			</d2l-ajax>
-
 		</div>
 	</template>
 
@@ -81,8 +64,7 @@
 				telemetryEndpoint: String,
 				_setImageUrl: String,
 				_imageClass: String,
-				_telemetrySetImageEvent: String,
-				_telemetryEvent: String
+				_telemetrySetImageEvent: String
 			},
 			behaviors: [
 				window.D2L.ImageSelector.LocalizeBehavior,
@@ -113,13 +95,6 @@
 
 				return '';
 			},
-			_onSetImageResponse: function(response) {
-				var status = response.detail.status === 200 ? 'success' : 'failure';
-				this._fireCourseImageMessage(status);
-			},
-			_onSetImageError: function() {
-				this._fireCourseImageMessage('failure');
-			},
 			_fireCourseImageMessage: function(status) {
 				this.fire('set-course-image', {
 					organization: this.organization,
@@ -129,27 +104,50 @@
 			},
 			_selectImage: function() {
 				this._setImageUrl = this._getSetImageUrl();
-				this.$.setImageRequest.generateRequest();
-				this._doTelemetrySetImageRequest();
-				this._fireCourseImageMessage('set');
-				this.fire('image-selector-tile-image-selected');
-			},
-			_updateImageSource: function() {
-				var courseImage = Polymer.dom(this.root).querySelector('img');
-				this._imageClass = 'd2l-image-selector-tile-hidden';
-				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
-				Polymer.dom(courseImage).setAttribute('sizes', '(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw');
-			},
-			_doTelemetrySetImageRequest: function() {
-				this._telemetryEvent = JSON.stringify({
+
+				var setImagePromise = window.d2lfetch
+					.fetch(new Request(this._setImageUrl, {
+						method: 'POST',
+						headers: {
+							Accept: 'application/vnd.siren+json'
+						}
+					}))
+					.then(function(response) {
+						if (response.ok) {
+							return response.json();
+						}
+						return Promise.reject();
+					})
+					.then(this._fireCourseImageMessage.bind(this, 'success'))
+					.catch(this._fireCourseImageMessage.bind(this, 'failure'));
+
+				var event = {
 					name: 'SelectedImage',
 					ts: Math.round(Date.now() / 1000),
 					imageId: this.image.getLinkByRel('self').href,
 					imageTags: this.image.properties.tags + ',' + this.image.properties.categories,
 					userId: this.userId,
 					tenantId: this.tenantId
-				});
-				this.$.telemetryRequest.generateRequest();
+				};
+				var telemetryPromise = window.d2lfetch
+					.fetch(new Request(this.telemetryEndpoint, {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json'
+						},
+						body: JSON.stringify(event)
+					}));
+
+				this._fireCourseImageMessage('set');
+				this.fire('image-selector-tile-image-selected');
+
+				return Promise.all([setImagePromise, telemetryPromise]);
+			},
+			_updateImageSource: function() {
+				var courseImage = Polymer.dom(this.root).querySelector('img');
+				this._imageClass = 'd2l-image-selector-tile-hidden';
+				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
+				Polymer.dom(courseImage).setAttribute('sizes', '(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw');
 			},
 			_showImage: function() {
 				this._imageClass = 'shown';

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "test": "npm run test:lint:js && npm run test:lint:wc && polymer test",
     "test:lint:js": "eslint --ext .js,.html . test/",
     "test:lint:wc": "polymer lint",
-    "test:no-lint": "wct -p"
+    "test:no-lint": "cross-env LAUNCHPAD_BROWSERS=chrome wct -p"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
     "bower": "^1.8.0",
+    "cross-env": "^5.0.5",
     "eslint": "^3.14.0",
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^1.7.0",
-    "polymer-cli": "^1.1.0"
+    "polymer-cli": "^1.5.5"
   }
 }

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.js
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.js
@@ -17,29 +17,27 @@ describe('<d2l-course-tile>', function() {
 	describe('loadMore', function() {
 		beforeEach(function() {
 			widget._showGrid = true;
-			widget.$.moreSearchImagesRequest.generateRequest = sinon.stub();
-			widget.$.moreDefaultImagesRequest.generateRequest = sinon.stub();
+			widget._fetchSirenEntity = sinon.stub().returns(Promise.resolve());
 			widget.$.lazyLoadSpinner.scrollIntoView = sinon.stub();
 		});
 
 		it('generates a moreSearchImagesRequest when a nextSearchResults page exists', function() {
 			widget._nextSearchResultPage = 'http://test.com';
 			widget.loadMore();
-			expect(widget.$.moreSearchImagesRequest.generateRequest.called).to.equal(true);
+			expect(widget._fetchSirenEntity.called).to.equal(true);
 		});
 
 		it('does not generate a moreSearchImagesRequest when showGrid is false', function() {
 			widget._nextSearchResultPage = 'http://test.com';
 			widget._showGrid = false;
-			widget.$.moreSearchImagesRequest.generateRequest = sinon.stub();
 			widget.loadMore();
-			expect(widget.$.moreSearchImagesRequest.generateRequest.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
 		});
 
 		it('does not generate a moreSearchImagesRequest when there is no next search page', function() {
 			widget._nextSearchResultPage = null;
 			widget.loadMore();
-			expect(widget.$.moreSearchImagesRequest.generateRequest.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
 		});
 
 		it('shows the spinner when generating a moreSearchImagesRequest', function() {
@@ -55,7 +53,7 @@ describe('<d2l-course-tile>', function() {
 			widget.searchImages = [];
 
 			widget.loadMore();
-			expect(widget.$.moreDefaultImagesRequest.generateRequest.called).to.equal(true);
+			expect(widget._fetchSirenEntity.called).to.equal(true);
 		});
 
 		it('does not generate a moreDefaultImagesRequest when there are search images', function() {
@@ -64,7 +62,7 @@ describe('<d2l-course-tile>', function() {
 			widget._searchImages = ['this is a search image!'];
 
 			widget.loadMore();
-			expect(widget.$.moreDefaultImagesRequest.generateRequest.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
 		});
 
 		it('does not generate a moreDefaultImagesRequest when there is no next default page', function() {
@@ -72,7 +70,7 @@ describe('<d2l-course-tile>', function() {
 			widget._searchImages = [];
 
 			widget.loadMore();
-			expect(widget.$.moreDefaultImagesRequest.generateRequest.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
 		});
 
 		it('does not generate a moreDefaultImagesRequest when showGrid is false', function() {
@@ -82,7 +80,7 @@ describe('<d2l-course-tile>', function() {
 			widget._showGrid = false;
 
 			widget.loadMore();
-			expect(widget.$.moreDefaultImagesRequest.generateRequest.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
 		});
 
 		it('shows the spinner when generating a moreDefaultImagesRequest', function() {
@@ -105,8 +103,8 @@ describe('<d2l-course-tile>', function() {
 		it('hides the spinner when no response is generated', function() {
 			widget.loadMore();
 			expect(widget._loadingSpinnerClass).to.equal('d2l-basic-image-selector-hidden');
-			expect(widget.$.moreSearchImagesRequest.generateRequest.called).to.equal(false);
-			expect(widget.$.moreDefaultImagesRequest.generateRequest.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
+			expect(widget._fetchSirenEntity.called).to.equal(false);
 		});
 	});
 
@@ -126,10 +124,8 @@ describe('<d2l-course-tile>', function() {
 
 	describe('_initialize', function() {
 		beforeEach(function() {
-			widget._parseEntity = sinon.stub().returns({});
 			widget.imageCatalogLocation = 'http://test.com';
 			widget._getChangeCourseImageLink = sinon.stub();
-			widget.$.imagesRequest.generateRequest = sinon.stub();
 			widget.$$('d2l-search-widget').clear = sinon.stub();
 			widget._getSearchStringValue = sinon.stub();
 			widget.organization = {
@@ -165,28 +161,11 @@ describe('<d2l-course-tile>', function() {
 
 		beforeEach(function() {
 			response = {
-				detail: {
-					status: 200,
-					xhr: { response: {} }
-				}
-			};
-
-			widget._parseEntity = sinon.stub().returns({
 				entities: [4, 5, 6]
-			});
+			};
 			widget._setNextPage = sinon.stub();
 			widget.updateImages = sinon.stub();
 			widget._doTelemetryNextPageRequest = sinon.stub();
-		});
-
-		describe('when status is not 200', function() {
-			it('hides the loading spinner', function() {
-				var badResponse = {
-					detail: { status: 500 }
-				};
-				widget._onImagesRequestResponse(badResponse, false, false);
-				expect(widget._loadingSpinnerClass).to.equal('d2l-basic-image-selector-hidden');
-			});
 		});
 
 		it('hides the loading spinner', function() {

--- a/test/d2l-image-selector-tile/d2l-image-selector-tile.html
+++ b/test/d2l-image-selector-tile/d2l-image-selector-tile.html
@@ -6,6 +6,7 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
+		<script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
 		<link rel="import" href="../../d2l-image-selector-tile.html">
 	</head>
 	<body>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,54 +1,7 @@
 {
   "plugins": {
     "local": {
-      "browsers": [{
-        "browserName": "firefox"
-      }]
-    },
-    "sauce": {
-      "disabled": true,
-      "browsers": [
-        {
-          "browserName": "chrome",
-          "platform": "OS X 10.11",
-          "version": ""
-        },
-        {
-          "browserName": "chrome",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "firefox",
-          "platform": "OS X 10.11",
-          "version": ""
-        },
-        {
-          "browserName": "firefox",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "safari",
-          "platform": "OS X 10.11",
-          "version": "9.0"
-        },
-        {
-          "browserName": "microsoftedge",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "internet explorer",
-          "platform": "Windows 10",
-          "version": "11"
-        },
-        {
-          "browserName": "internet explorer",
-          "platform": "Windows 8",
-          "version": "10"
-        }
-      ]
+      "browsers": ["chrome"]
     }
   }
 }


### PR DESCRIPTION
The recent version bump to d2l-search-widget removed the cache-responses functionality, so remove it. Instead, caching should be done by using the d2l-fetch-simple-cache middleware (d2l-search-widget now uses d2l-fetch internally).

We noticed some significant performance gains by switching from d2l-ajax to d2l-fetch in d2l-my-courses; not really expecting to see as much of a benefit here, but the API is nicer to work with, and it allows us to add caching and some other goodness page-wide, which is legit.

Going to probably follow this up with one or two PRs, as there's a bunch of stuff in here that we've since learned how to do more nicely :) (but not related to the US)