### PR TITLE
Use siren-parser-import, and parse organization

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,8 @@
     "d2l-loading-spinner": "^5.0.5",
     "d2l-localize-behavior": "^1.0.1",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.0",
-    "d2l-search-widget": "Brightspace/d2l-search-widget-ui#^2.0.1"
+    "d2l-search-widget": "Brightspace/d2l-search-widget-ui#^2.0.1",
+    "siren-parser-import": "Brightspace/siren-parser-import#^6.5.0"
   },
   "devDependencies": {
     "d2l-typography": "^5.5.0",

--- a/d2l-basic-image-selector.html
+++ b/d2l-basic-image-selector.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
+<link rel="import" href="../siren-parser-import/siren-parser-global.html">
 <link rel="import" href="d2l-image-tile-grid.html">
 <link rel="import" href="localize-behavior.html">
 
@@ -97,7 +98,6 @@
 			size="100">
 		</d2l-loading-spinner>
 	</template>
-	<script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
 	<script>
 		Polymer({
 			is: 'd2l-basic-image-selector',
@@ -128,6 +128,9 @@
 				'd2l-simple-overlay-opening': '_initialize',
 				'd2l-simple-overlay-closed': '_clear'
 			},
+			observers: [
+				'_onOrganizationChanged(organization)'
+			],
 			attached: function() {
 				this.listen(
 					this.$$('d2l-search-widget'),
@@ -210,6 +213,11 @@
 				}
 				this._setNextPage(responseEntity, isDefault);
 				this._updateImages();
+			},
+			_onOrganizationChanged: function(organization) {
+				if (!organization.getLinkByRel) {
+					this.organization = window.D2L.Hypermedia.Siren.Parse(organization);
+				}
 			},
 			_initialize: function() {
 				this._searchAction = JSON.stringify(this._getSearchAction());

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,11 +36,11 @@
 				document.body.querySelector('d2l-basic-image-selector')._initialize();
 			});
 
-			template.organization = window.D2L.Hypermedia.Siren.Parse({
+			template.organization = {
 				properties: {
 					name: 'name'
 				}
-			});
+			};
 
 			document.getElementById('loadMore').addEventListener('click', function() {
 				document.body.querySelector('d2l-basic-image-selector').loadMore();

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.js
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.js
@@ -130,6 +130,10 @@ describe('<d2l-course-tile>', function() {
 			};
 		});
 
+		it('parses the passed-in organization, if not already parsed', function() {
+			expect(widget.organization.getLinkByRel).to.be.a('function');
+		});
+
 		it('clears the search widget', function() {
 			widget._initialize();
 			expect(widget.$$('d2l-search-widget').clear.called).to.equal(true);


### PR DESCRIPTION
Missed this repo - should be using the siren-parser-import now, as it allows for us to take advantage of versioning (which prevents different versions of siren-parser from fighting with each other).

Also, parse the passed-in organization if it's not already parsed.