### PR TITLE
Remove unneeded reference to CDN siren-parser

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "d2l-colors": "^3.1.2",
-    "d2l-course-image": "Brightspace/course-image#^2.0.0",
+    "d2l-course-image": "Brightspace/course-image#^2.1.0",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.7.0",
     "d2l-icons": "^4.5.1",
     "d2l-loading-spinner": "^6.0.2",

--- a/test/d2l-image-selector-tile/d2l-image-selector-tile.html
+++ b/test/d2l-image-selector-tile/d2l-image-selector-tile.html
@@ -6,7 +6,6 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
 		<link rel="import" href="../../d2l-image-selector-tile.html">
 	</head>
 	<body>

--- a/test/d2l-image-selector-tile/d2l-image-selector-tile.js
+++ b/test/d2l-image-selector-tile/d2l-image-selector-tile.js
@@ -6,13 +6,13 @@ describe('<d2l-image-selector-tile>', function() {
 
 	beforeEach(function() {
 		widget = fixture('d2l-image-selector-tile-fixture');
-		widget.image = window.D2L.Hypermedia.Siren.Parse({
+		widget.image = {
 			links: [{
 				rel: ['self'],
 				href: 'http://example.com'
 			}],
 			properties: {}
-		});
+		};
 	});
 
 	it('loads element', function() {


### PR DESCRIPTION
Since the tile will now accept both parsed and un-parsed Entity input, the reference to the CDN-ified script is no longer needed.