### PR TITLE
US107584 - Use the latest d2l-search-widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-node_js: node
+node_js:
+- "11"
 addons:
   chrome: stable
 script:

--- a/d2l-basic-image-selector.js
+++ b/d2l-basic-image-selector.js
@@ -74,7 +74,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-basic-image-selector">
 		</style>
 
 		<div class="top-section">
-			<d2l-search-widget id="image-search" class="small" search-action="[[_searchAction]]" placeholder-text="[[localize('search')]]" search-field-name="search">
+			<d2l-search-widget id="image-search" search-action="[[_searchAction]]" placeholder-text="[[localize('search')]]" search-field-name="search">
 			</d2l-search-widget>
 
 			<template is="dom-if" if="{{_organizationChangeImageHref}}" restamp="true">
@@ -154,14 +154,9 @@ Polymer({
 	_searchImages: [],
 	_defaultImages: [],
 	_searchResultsChanged: function(response) {
-		var searchRegex = /search=([^&]*)/,
-			searchHref = decodeURIComponent(response.detail.getLinkByRel('self').href),
-			match = searchRegex.exec(searchHref),
-			userSearchText = (match.length > 1) ? match[1] : null;
-
-		if (userSearchText) {
-			this._displaySearchResults(userSearchText);
-			this._setNextPage(response.detail, false);
+		if (response.detail.searchValue) {
+			this._displaySearchResults(response.detail.searchValue, response.detail.searchResponse);
+			this._setNextPage(response.detail.searchResponse, false);
 		} else {
 			// Throw out empty searches
 			// TODO: d2l-search-widget property that sends events instead of making network calls
@@ -170,13 +165,12 @@ Polymer({
 
 		this._updateImages();
 	},
-	_displaySearchResults: function(userSearchText) {
-		var searchWidget = this.$$('d2l-search-widget'),
-			delimiter = '$$$DELIMITER???',
+	_displaySearchResults: function(userSearchText, searchResults) {
+		var delimiter = '$$$DELIMITER???',
 			noResultsText = this.localize('images.noResults', 'search', delimiter),
 			noResultsSplit = noResultsText.split(delimiter);
 
-		this._searchImages = searchWidget.searchResults.entities || [];
+		this._searchImages = searchResults.entities || [];
 		this._noResultsTextStart = noResultsSplit[0];
 		this._noResultsTextMid = userSearchText;
 		this._noResultsTextEnd = noResultsSplit[1];

--- a/demo/index.html
+++ b/demo/index.html
@@ -71,12 +71,13 @@ import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
 import '@polymer/iron-demo-helpers/demo-snippet.js';
 import 'd2l-typography/d2l-typography.js';
 import '../d2l-basic-image-selector.js';
+import SirenParse from 'siren-parser';
 
 var imageSelector = document.body.querySelector('d2l-basic-image-selector');
 imageSelector.courseImageUploadCb = function() {
 	console.log('courseImageUploadCb called!'); // eslint-disable-line no-console
 };
-imageSelector.organization = window.D2L.Hypermedia.Siren.Parse({
+imageSelector.organization = SirenParse({
 	properties: {
 		name: 'name'
 	},

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#semver:^3",
-    "d2l-search-widget": "Brightspace/d2l-search-widget-ui#semver:^4",
+    "d2l-search-widget": "Brightspace/d2l-search-widget-ui#semver:^5",
     "@polymer/polymer": "^3.0.0",
     "siren-parser": "^8.0.0"
   }

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.js
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.js
@@ -307,45 +307,46 @@ describe('<d2l-course-tile>', function() {
 	});
 
 	describe('_displaySearchResults', function() {
-		var userSearchText;
+		var userSearchText,
+			searchResults;
 
 		beforeEach(function() {
-			widget.$$('d2l-search-widget').searchResults = {
+			userSearchText = 'SEARCH';
+			searchResults = {
 				entities: [1, 2, 3]
 			};
-			userSearchText = 'SEARCH';
 		});
 
 		it('sets _noResultsTextStart to the first half of the langTerm', function() {
-			widget._displaySearchResults(userSearchText);
+			widget._displaySearchResults(userSearchText, searchResults);
 			expect(widget._noResultsTextStart).to.equal('No results found for ');
 		});
 
 		it('sets _noResultsTextMid to the search term', function() {
-			widget._displaySearchResults(userSearchText);
+			widget._displaySearchResults(userSearchText, searchResults);
 			expect(widget._noResultsTextMid).to.equal(userSearchText);
 		});
 
 		it('sets _noResultsTextEnd to the second half of the langTerm', function() {
-			widget._displaySearchResults(userSearchText);
+			widget._displaySearchResults(userSearchText, searchResults);
 			expect(widget._noResultsTextEnd).to.equal('.');
 		});
 
 		it('sets _searchImages to the result from the search widget', function() {
-			widget._displaySearchResults(userSearchText);
-			expect(widget._searchImages).to.deep.equal(widget.$$('d2l-search-widget').searchResults.entities);
+			widget._displaySearchResults(userSearchText, searchResults);
+			expect(widget._searchImages).to.deep.equal(searchResults.entities);
 		});
 
 		it('sets _showGrid to true if there was search results', function() {
-			widget._displaySearchResults(userSearchText);
+			widget._displaySearchResults(userSearchText, searchResults);
 			expect(widget._showGrid).to.equal(true);
 		});
 
 		it('sets _showGrid to false if there was no search results', function() {
-			widget.$$('d2l-search-widget').searchResults = {
+			searchResults = {
 				entities: null
 			};
-			widget._displaySearchResults(userSearchText);
+			widget._displaySearchResults(userSearchText, searchResults);
 			expect(widget._showGrid).to.equal(false);
 		});
 	});
@@ -362,17 +363,23 @@ describe('<d2l-course-tile>', function() {
 
 			emptyResponse = {
 				detail: {
-					getLinkByRel: sinon.stub().returns({
-						href: href
-					})
+					searchValue: '',
+					searchResponse: {
+						getLinkByRel: sinon.stub().returns({
+							href: href
+						})
+					}
 				}
 			};
 
 			response = {
 				detail: {
-					getLinkByRel: sinon.stub().returns({
-						href: searchHref
-					})
+					searchValue: 'TREE',
+					searchResponse: {
+						getLinkByRel: sinon.stub().returns({
+							href: searchHref
+						})
+					}
 				}
 			};
 
@@ -385,19 +392,20 @@ describe('<d2l-course-tile>', function() {
 			it('displays the default results', function() {
 				widget._searchResultsChanged(emptyResponse);
 				expect(widget._displayDefaultResults.called).to.equal(true);
+				expect(widget._displaySearchResults.called).to.equal(false);
 			});
 		});
 
 		describe('not empty search', function() {
 			it('displays the results', function() {
 				widget._searchResultsChanged(response);
-				expect(widget._displaySearchResults.calledWith('TREE')).to.equal(true);
+				expect(widget._displaySearchResults.calledWithExactly('TREE', response.detail.searchResponse)).to.equal(true);
 				expect(widget._displayDefaultResults.called).to.equal(false);
 			});
 
 			it('sets the next page', function() {
 				widget._searchResultsChanged(response);
-				expect(widget._setNextPage.calledWith(response.detail)).to.equal(true);
+				expect(widget._setNextPage.calledWith(response.detail.searchResponse)).to.equal(true);
 				expect(widget._displayDefaultResults.called).to.equal(false);
 			});
 		});


### PR DESCRIPTION
- Adjusts to the new event format from the search widget
- No longer accesses the search results directly from the widget itself (uses event response instead)

This will be a minor update, but I'm not going to merge this until `my-courses` is ready to merge as well (otherwise BSI conflicts will arise).