### PR TITLE
Use d2l-dialog-fullscreen component instead of overlay

### DIFF
--- a/d2l-basic-image-selector.js
+++ b/d2l-basic-image-selector.js
@@ -110,6 +110,10 @@ Polymer({
 	ready: function() {
 		this._images = this._defaultImages;
 	},
+	constructor: function() {
+		this._initialize = this._initialize.bind(this);
+		this._clear = this._clear.bind(this);
+	},
 	properties: {
 		courseImageUploadCb: Function,
 		imageCatalogLocation: String,
@@ -150,6 +154,16 @@ Polymer({
 			'd2l-search-widget-results-changed',
 			'_searchResultsChanged'
 		);
+	},
+	connectedCallback: function() {
+		//super.connectedCallback();
+		window.addEventListener('d2l-dialog-open', this._initialize);
+		window.addEventListener('d2l-dialog-close', this._clear);
+	},
+	disconnectedCallback: function() {
+		window.removeEventListener('d2l-dialog-open', this._initialize);
+		window.removeEventListener('d2l-dialog-close', this._clear);
+		//super.disconnectedCallback();
 	},
 	_searchImages: [],
 	_defaultImages: [],

--- a/d2l-basic-image-selector.js
+++ b/d2l-basic-image-selector.js
@@ -109,10 +109,10 @@ Polymer({
 	is: 'd2l-basic-image-selector',
 	ready: function() {
 		this._images = this._defaultImages;
-	},
-	constructor: function() {
 		this._initialize = this._initialize.bind(this);
 		this._clear = this._clear.bind(this);
+		window.addEventListener('d2l-dialog-open', this._initialize);
+		window.addEventListener('d2l-dialog-close', this._clear);
 	},
 	properties: {
 		courseImageUploadCb: Function,
@@ -154,16 +154,6 @@ Polymer({
 			'd2l-search-widget-results-changed',
 			'_searchResultsChanged'
 		);
-	},
-	connectedCallback: function() {
-		//super.connectedCallback();
-		window.addEventListener('d2l-dialog-open', this._initialize);
-		window.addEventListener('d2l-dialog-close', this._clear);
-	},
-	disconnectedCallback: function() {
-		window.removeEventListener('d2l-dialog-open', this._initialize);
-		window.removeEventListener('d2l-dialog-close', this._clear);
-		//super.disconnectedCallback();
 	},
 	_searchImages: [],
 	_defaultImages: [],

--- a/d2l-basic-image-selector.js
+++ b/d2l-basic-image-selector.js
@@ -109,10 +109,6 @@ Polymer({
 	is: 'd2l-basic-image-selector',
 	ready: function() {
 		this._images = this._defaultImages;
-		this._initialize = this._initialize.bind(this);
-		this._clear = this._clear.bind(this);
-		window.addEventListener('d2l-dialog-open', this._initialize);
-		window.addEventListener('d2l-dialog-close', this._clear);
 	},
 	properties: {
 		courseImageUploadCb: Function,
@@ -135,8 +131,8 @@ Polymer({
 	},
 	behaviors: [ D2L.PolymerBehaviors.ImageSelector.LocalizeBehavior ],
 	listeners: {
-		'd2l-simple-overlay-opening': '_initialize',
-		'd2l-simple-overlay-closed': '_clear'
+		'd2l-simple-overlay-opening': 'initializeSearch',
+		'd2l-simple-overlay-closed': 'clearSearch'
 	},
 	observers: [
 		'_onOrganizationChanged(organization)'
@@ -230,7 +226,7 @@ Polymer({
 			this.organization = SirenParse(organization);
 		}
 	},
-	_initialize: function() {
+	initializeSearch: function() {
 		this._searchAction = JSON.stringify(this._getSearchAction());
 		this._showGrid = true;
 		this.$$('d2l-search-widget').clear();
@@ -249,7 +245,7 @@ Polymer({
 				.then(this._onDefaultImagesRequestResponse.bind(this));
 		}
 	},
-	_clear: function() {
+	clearSearch: function() {
 		this._searchString = '';
 		this._images = [];
 		this._searchImages = [];

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "wct-browser-legacy": "^1.0.1",
     "whatwg-fetch": "^2.0.0"
   },
-  "version": "4.1.4",
+  "version": "4.1.5",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.js
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.js
@@ -117,7 +117,7 @@ describe('<d2l-course-tile>', function() {
 		});
 	});
 
-	describe('_initialize', function() {
+	describe('initializeSearch', function() {
 		beforeEach(function() {
 			widget.imageCatalogLocation = 'http://test.com';
 			widget._getChangeCourseImageLink = sinon.stub();
@@ -135,22 +135,22 @@ describe('<d2l-course-tile>', function() {
 		});
 
 		it('clears the search widget', function() {
-			widget._initialize();
+			widget.initializeSearch();
 			expect(widget.$$('d2l-search-widget').clear.called).to.equal(true);
 		});
 
 		it('shows the grid', function() {
-			widget._initialize();
+			widget.initializeSearch();
 			expect(widget._showGrid).to.equal(true);
 		});
 
 		it("generates a request using the passed in organization's name", function() {
-			widget._initialize();
+			widget.initializeSearch();
 			expect(widget._getSearchStringValue.calledWith(widget.organization.properties.name)).to.equal(true);
 		});
 
 		it('generates a request even if no oraganization was passed in', function() {
-			widget._initialize();
+			widget.initializeSearch();
 			expect(widget._getSearchStringValue.called).to.equal(true);
 		});
 	});
@@ -230,7 +230,7 @@ describe('<d2l-course-tile>', function() {
 			widget._searchImages = [1];
 			widget._defaultImages = [1];
 
-			widget._clear();
+			widget.clearSearch();
 
 			expect(widget._searchImages).to.deep.equal([]);
 			expect(widget._showGrid).to.equal(true);


### PR DESCRIPTION
Updating the show all courses/course banner widget to use the d2l-dialog-fullscreen component rather than d2l-simple-overlay.

This is part of a set of PRs all needed to make the image-selector component work with d2l-dialog-fullscreen: 

- https://github.com/Brightspace/d2l-my-courses-ui/pull/892
- https://github.com/Brightspace/d2l-image-banner-overlay/pull/112
- https://github.com/Brightspace/image-selector/pull/48
